### PR TITLE
Add catalog name check to username available check.

### DIFF
--- a/backend/src/resolvers.ts
+++ b/backend/src/resolvers.ts
@@ -415,7 +415,14 @@ export const resolvers: {
         .getCustomRepository(UserRepository)
         .getUserByUsername(username);
 
-      return user == null;
+
+      const catalog = await context
+        .connection
+        .manager
+        .getCustomRepository(CatalogRepository)
+        .findCatalogBySlug({slug: username});
+
+      return user == null && catalog == null;
     },
 
     emailAddressAvailable: async(

--- a/docs/docs/registry-api.md
+++ b/docs/docs/registry-api.md
@@ -40,7 +40,7 @@ You can submit an API key in the "Authorization" HTTP request header to authenti
 
 ```
 {
-    "Authoriztion": "Bearer YOUR-API-TOKEN-HERE"
+    "Authorization": "Bearer YOUR-API-TOKEN-HERE"
 }
 ```
 


### PR DESCRIPTION
Usernames that clash with existing catalog names can not be claimed, as we would not be able to create a catalog for them. May deal with this in a more complex way in the future.