### PR TITLE
Fixes for the forgot password flow

### DIFF
--- a/backend/src/entity/User.ts
+++ b/backend/src/entity/User.ts
@@ -91,8 +91,8 @@ export class User extends BaseModel {
     emailVerified: boolean;
 
     /** Unique token to allow for password recovery. */
-    @Column({ nullable: true, name: "password_recovery_token" })
-    passwordRecoveryToken: string;
+    @Column({ nullable: true, name: "password_recovery_token", type: "varchar" })
+    passwordRecoveryToken: string | null;
 
     /** The date on which the passwordRecoveryToken was created */
     @Column({ nullable: true, name: "password_recovery_token_date" })

--- a/backend/src/repository/UserRepository.ts
+++ b/backend/src/repository/UserRepository.ts
@@ -342,7 +342,7 @@ export class UserRepository extends Repository<User> {
                 return dbUser;
             })
             .then(async (user: User) => {
-                await sendForgotPasswordEmail(user, user.passwordRecoveryToken);
+                await sendForgotPasswordEmail(user, user.passwordRecoveryToken as string);
             });
     }
 
@@ -364,6 +364,7 @@ export class UserRepository extends Repository<User> {
 
             const newPasswordHash = hashPassword(value.newPassword, dbUser.passwordSalt);
             dbUser.passwordHash = newPasswordHash;
+            dbUser.passwordRecoveryToken = null;
 
             await transaction.save(dbUser);
         });

--- a/frontend/src/app/auth-callbacks/password-recovery/password-recovery.component.html
+++ b/frontend/src/app/auth-callbacks/password-recovery/password-recovery.component.html
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="title">Reset password</div>
-    <ng-container [ngSwitch]="state">
+    <ng-container [ngSwitch]="passwordResetState">
         <ng-container *ngSwitchDefault>
             <div class="label">Enter new password</div>
             <app-input
@@ -15,8 +15,8 @@
                 type="raised"
                 (click)="submit()"
             >
-                <span *ngIf="state !== 'LOADING'">Reset Password</span>
-                <mat-spinner [diameter]="20" *ngIf="state === 'LOADING'"></mat-spinner>
+                <span *ngIf="passwordResetState !== 'LOADING'">Reset Password</span>
+                <mat-spinner [diameter]="20" *ngIf="passwordResetState === 'LOADING'"></mat-spinner>
             </button>
         </ng-container>
         <ng-container *ngSwitchCase="'ERROR'">

--- a/frontend/src/app/auth-callbacks/password-recovery/password-recovery.component.ts
+++ b/frontend/src/app/auth-callbacks/password-recovery/password-recovery.component.ts
@@ -17,7 +17,7 @@ export class PasswordRecoveryComponent implements OnInit {
     password = new FormControl("", {
         asyncValidators: [newPasswordValidator()]
     });
-    state: PageState = "SUCCESS";
+    passwordResetState: PageState = "INIT";
     error: string = "";
 
     constructor(
@@ -40,16 +40,18 @@ export class PasswordRecoveryComponent implements OnInit {
             .subscribe(
                 (response) => {
                     if (response.errors) {
-                        this.error = "Error occured. Password reset failed!";
-                        this.state = "ERROR";
+                        this.error =
+                            "An error occured. Please try to login and use the 'forgot password' link again. Or contact support.";
+                        this.passwordResetState = "ERROR";
                         return;
                     }
 
-                    this.state = "SUCCESS";
+                    this.passwordResetState = "SUCCESS";
                 },
                 () => {
-                    this.error = "Error occured. Password reset failed!";
-                    this.state = "ERROR";
+                    this.error =
+                        "An error occured. Please try to login and use the 'forgot password' link again. Or contact support.";
+                    this.passwordResetState = "ERROR";
                 }
             );
     }


### PR DESCRIPTION
I found that the "recover-password" component didn't allow the user to enter their password before showing a success message. And that a password recovery link could be reused multiple times. 

- Backend now sets password recovery token null after successfully using it
- Frontend now allows user to enter a new password
