### PR TITLE
bugfix/DPM - Fix rendering issue with builder io pages

### DIFF
--- a/frontend/src/app/imported/builder-io-component/builder-io.component.ts
+++ b/frontend/src/app/imported/builder-io-component/builder-io.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Component, ElementRef, Input } from "@angular/core";
+import { AfterViewInit, Component, ElementRef, Input } from "@angular/core";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { BuilderIOService } from "../resource-importer.service";
@@ -8,7 +8,7 @@ import { BuilderIOService } from "../resource-importer.service";
     templateUrl: "./builder-io.component.html",
     styleUrls: ["./builder-io.component.scss"]
 })
-export class BuilderIOComponent implements AfterViewChecked {
+export class BuilderIOComponent implements AfterViewInit {
     private readonly JAVASCRIPT_ELEMENT_TYPE = "script";
     private readonly JAVASCRIPT_SCRIPT_TYPE = "text/javascript";
 
@@ -25,9 +25,9 @@ export class BuilderIOComponent implements AfterViewChecked {
 
     private destroy$ = new Subject();
 
-    constructor(private builderIOService: BuilderIOService, private elementRef: ElementRef) {}
+    constructor(private builderIOService: BuilderIOService, private elementRef: ElementRef) { }
 
-    public ngAfterViewChecked(): void {
+    public ngAfterViewInit(): void {
         this.loadJavascriptAndInjectIntoTemplate();
     }
 


### PR DESCRIPTION
`AfterViewChecked` is called after every template change triggered by the change detector ref, I believe this was a leftover during testing.
Replaced it with the right lifecycle method; `AfterViewInit`, which is only called once when the template gets initialized.