### PR TITLE
timeplus sink connector

### DIFF
--- a/client-lib/src/connector/ConnectorUtil.ts
+++ b/client-lib/src/connector/ConnectorUtil.ts
@@ -17,6 +17,7 @@ import { FTXConnectorDescription } from "./ftx/FTXConnectorDescription";
 import { BinanceConnectorDescription } from "./binance/BinanceConnectorDescription";
 import { KafkaConnectorDescription } from "./stream/kafka/KafkaConnectorDescription";
 import { GeminiConnectorDescription } from "./gemini/GeminiConnectorDescription";
+import { TimeplusConnectorDescription } from "./timeplus/TimeplusConnectorDescription";
 
 export const CONNECTORS: ConnectorDescription[] = [
     new BigQueryConnectorDescription(),
@@ -33,6 +34,7 @@ export const CONNECTORS: ConnectorDescription[] = [
     new BinanceConnectorDescription(),
     new KafkaConnectorDescription(),
     new GeminiConnectorDescription(),
+    new TimeplusConnectorDescription(),
 
     // These generic file-based connectors should always be at the bottom of the list
     // so that more specific services are tried first during the "supportsUrl"

--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -1,0 +1,117 @@
+/* eslint-disable camelcase */
+import { DPMConfiguration, nameToSlug, Parameter, ParameterType } from "datapm-lib";
+import { Connector } from "../Connector";
+import { TYPE } from "./TimeplusConnectorDescription";
+import fetch from "cross-fetch";
+import { JobContext } from "../../task/Task";
+
+const printedTimeplusLoginMessage = false;
+
+export class TimeplusConnector implements Connector {
+    getType(): string {
+        return TYPE;
+    }
+
+    requiresConnectionConfiguration(): boolean {
+        return true;
+    }
+
+    userSelectableConnectionHistory(): boolean {
+        return true;
+    }
+
+    requiresCredentialsConfiguration(): boolean {
+        return true;
+    }
+
+    async getRepositoryIdentifierFromConfiguration(connectionConfiguration: DPMConfiguration): Promise<string> {
+        if (typeof connectionConfiguration.host !== "string") {
+            throw new Error("Timeplus host not set");
+        }
+        return connectionConfiguration.host;
+    }
+
+    async getCredentialsIdentifierFromConfiguration(
+        _connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration
+    ): Promise<string | undefined> {
+        if (credentialsConfiguration.token != null) {
+            const token = credentialsConfiguration.token as string;
+            return token;
+            // only show the first 4 chars and the last 4 chars
+            // return token.substring(0, 4) + "**" + token.substring(token.length - 3);
+        }
+
+        return undefined;
+    }
+
+    getConnectionParameters(connectionConfiguration: DPMConfiguration): Parameter[] | Promise<Parameter[]> {
+        const parameters: Parameter[] = [];
+
+        if (connectionConfiguration.host == null) {
+            parameters.push({
+                name: "host",
+                type: ParameterType.Text,
+                stringMinimumLength: 1,
+                configuration: connectionConfiguration,
+                message: "Host Name(e.g. a.beta.timeplus.com)?"
+            });
+        }
+
+        return parameters;
+    }
+
+    getCredentialsParameters(
+        _connectionConfiguration: DPMConfiguration,
+        authenticationConfiguration: DPMConfiguration,
+        jobContext: JobContext
+    ): Parameter[] | Promise<Parameter[]> {
+        const parameters: Parameter[] = [];
+
+        if (authenticationConfiguration.token == null) {
+            parameters.push({
+                configuration: authenticationConfiguration,
+                type: ParameterType.Password,
+                name: "token",
+                message: "API Token?"
+            });
+        }
+
+        return parameters;
+    }
+
+    async testConnection(): Promise<string | true> {
+        // TODO test basic HTTP connection to API
+        return true;
+    }
+
+    async testCredentials(
+        connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration
+    ): Promise<string | true> {
+        const authToken = getAuthToken(credentialsConfiguration);
+        const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
+
+        const resp = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${authToken}`,
+                Accept: "application/json"
+            }
+        });
+
+        if (resp.status !== 200) {
+            return "Received status code " + resp.status + " from Timeplus.";
+        }
+
+        return true;
+    }
+}
+export function getAuthToken(credentialsConfiguration: DPMConfiguration): string {
+    const accessToken = credentialsConfiguration.token as string;
+
+    if (accessToken == null) {
+        throw new Error("Timeplus token is not set.");
+    }
+
+    return accessToken;
+}

--- a/client-lib/src/connector/timeplus/TimeplusConnectorDescription.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnectorDescription.ts
@@ -1,0 +1,38 @@
+import { Connector, ConnectorDescription } from "../Connector";
+import { SinkDescription } from "../Sink";
+import { SourceDescription } from "../Source";
+
+export const DISPLAY_NAME = "Timeplus";
+export const TYPE = "Timeplus";
+
+export class TimeplusConnectorDescription implements ConnectorDescription {
+    getDisplayName(): string {
+        return DISPLAY_NAME;
+    }
+
+    getType(): string {
+        return TYPE;
+    }
+
+    async getConnector(): Promise<Connector> {
+        const source = await import("./TimeplusConnector");
+        return new source.TimeplusConnector();
+    }
+
+    async getSourceDescription(): Promise<SourceDescription | null> {
+        return null;
+    }
+
+    async getSinkDescription(): Promise<SinkDescription | null> {
+        const source = await import("./TimeplusSinkDescription");
+        return new source.TimeplusSinkDescription();
+    }
+
+    hasSource(): boolean {
+        return false;
+    }
+
+    hasSink(): boolean {
+        return true;
+    }
+}

--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -1,0 +1,353 @@
+/* eslint-disable camelcase */
+import {
+    DPMConfiguration,
+    PackageFile,
+    Parameter,
+    SinkState,
+    Schema,
+    UpdateMethod,
+    SinkStateKey,
+    SchemaIdentifier,
+    RecordStreamContext,
+    ParameterType,
+    DPMRecord
+} from "datapm-lib";
+import { JSONSchema7TypeName } from "json-schema";
+import { Transform } from "stream";
+import { JobContext } from "../../task/Task";
+import { Maybe } from "../../util/Maybe";
+import { StreamSetProcessingMethod } from "../../util/StreamToSinkUtil";
+import { CommitKey, Sink, SinkSupportedStreamOptions, WritableWithContext } from "../Sink";
+import { getAuthToken } from "./TimeplusConnector";
+import { DISPLAY_NAME, TYPE } from "./TimeplusConnectorDescription";
+import { fetch } from "cross-fetch";
+import { SemVer } from "semver";
+import { BatchingTransform } from "../../transforms/BatchingTransform";
+
+type TimeplusColumn = {
+    name: string;
+    type: string;
+};
+
+type TimeplusColumns = Array<TimeplusColumn>;
+
+type TimeplusStream = {
+    name: string;
+    columns: TimeplusColumns;
+};
+
+type ListStreamsResponse = Array<TimeplusStream>;
+
+export class TimeplusSink implements Sink {
+    activeStream: string;
+
+    getType(): string {
+        return TYPE;
+    }
+
+    getDisplayName(): string {
+        return DISPLAY_NAME;
+    }
+
+    isStronglyTyped(): boolean | Promise<boolean> {
+        return true;
+    }
+
+    async getParameters(
+        catalogSlug: string | undefined,
+        packageFile: PackageFile,
+        connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration,
+        configuration: DPMConfiguration,
+        jobContext: JobContext
+    ): Promise<Parameter[]> {
+        configuration.schemaStreamNames = {};
+
+        for (const schema of packageFile.schemas) {
+            if (schema.title == null) throw new Error("Schema has no title");
+
+            const schemaReference: SchemaIdentifier = {
+                registryUrl: "",
+                catalogSlug: catalogSlug as string,
+                packageSlug: packageFile.packageSlug as string,
+                majorVersion: new SemVer(packageFile.version).major,
+                schemaTitle: schema.title as string
+            };
+
+            const TimeplusStreamName =
+                schemaReference.catalogSlug +
+                "_" +
+                schemaReference.packageSlug +
+                "_" +
+                schemaReference.majorVersion +
+                "_" +
+                schemaReference.schemaTitle;
+
+            if (configuration["stream-name-" + schema.title] == null) {
+                return [
+                    {
+                        type: ParameterType.Text,
+                        name: "stream-name-" + schema.title,
+                        configuration,
+                        message: "Stream for " + schema.title + " records?",
+                        defaultValue: TimeplusStreamName
+                    }
+                ];
+            }
+
+            await this.getOrCreateStream(
+                schema,
+                connectionConfiguration,
+                credentialsConfiguration,
+                configuration,
+                jobContext
+            );
+        }
+
+        return [] as Parameter[];
+    }
+
+    getSupportedStreamOptions(): SinkSupportedStreamOptions {
+        return {
+            streamSetProcessingMethods: [StreamSetProcessingMethod.PER_STREAM_SET],
+            updateMethods: [UpdateMethod.APPEND_ONLY_LOG, UpdateMethod.CONTINUOUS, UpdateMethod.BATCH_FULL_SET]
+        };
+    }
+
+    async getWriteable(
+        schema: Schema,
+        connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration,
+        configuration: DPMConfiguration,
+        _updateMethod: UpdateMethod,
+        replaceExistingData: boolean,
+        jobContext: JobContext
+    ): Promise<WritableWithContext> {
+        if (!configuration.schemaStreamNames) {
+            throw new Error("Requires configuration.schemaStreamNames");
+        }
+
+        if (schema.title == null) throw new Error("Schema has no title");
+
+        if (schema.properties == null) throw new Error("Schema properties not definied, and are required");
+        const keys = Object.keys(schema.properties);
+
+        const authToken = getAuthToken(credentialsConfiguration);
+
+        return {
+            getCommitKeys: () => {
+                return [] as CommitKey[];
+            },
+            outputLocation: `https://${connectionConfiguration.host}/api/v1beta1/streams`,
+            lastOffset: undefined,
+            transforms: [new BatchingTransform(100, 100)],
+            writable: new Transform({
+                objectMode: true,
+                transform: async (
+                    records: RecordStreamContext[],
+                    _encoding: string,
+                    callback: (error?: Error | null, data?: RecordStreamContext) => void
+                ) => {
+                    const events = records.map((r) => r.recordContext.record);
+
+                    const columns: string[] = [];
+                    const rows: (string | undefined)[][] = [];
+                    for (let i = 0; i < events.length; i++) {
+                        const event: DPMRecord = events[i];
+                        const row = [];
+                        for (const key of keys) {
+                            const columnName = key;
+                            const columnValue = event[key];
+                            if (i === 0) {
+                                columns.push(columnName);
+                            }
+                            row.push(columnValue?.toString());
+                        }
+                        rows.push(row);
+                    }
+                    const data = {
+                        columns: columns,
+                        data: rows
+                    };
+                    const ingestURL = `https://${connectionConfiguration.host}/api/v1beta1/streams/${
+                        configuration["stream-name-" + schema.title]
+                    }/ingest`;
+                    // jobContext.print("INFO", `ingestURL: ${ingestURL}`);
+                    const response = await fetch(ingestURL, {
+                        method: "POST",
+                        headers: {
+                            Authorization: `Bearer ${authToken}`,
+                            "Content-Type": "application/json",
+                            Accept: "application/json"
+                        },
+                        body: JSON.stringify(data)
+                    });
+
+                    // shall we use 202?
+                    if (response.status !== 200) {
+                        callback(
+                            new Error(`Unexpected response status ${response.status} body ${await response.text()}`)
+                        );
+                        return;
+                    }
+
+                    callback(null, records[records.length - 1]);
+                }
+            })
+        };
+    }
+
+    async commitAfterWrites(
+        _connectionConfiguration: DPMConfiguration,
+        _credentialsConfiguration: DPMConfiguration,
+        _configuration: DPMConfiguration,
+        _commitKeys: CommitKey[],
+        _sinkStateKey: SinkStateKey,
+        _sinkState: SinkState,
+        _jobContext: JobContext
+    ): Promise<void> {
+        // TODO save the sink state
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    filterDefaultConfigValues(): void {}
+
+    async getSinkState(
+        _connectionConfiguration: DPMConfiguration,
+        _credentialsConfiguration: DPMConfiguration,
+        _configuration: DPMConfiguration,
+        _sinkStateKey: SinkStateKey,
+        _jobContext: JobContext
+    ): Promise<Maybe<SinkState>> {
+        // TODO get the sink state
+        return null;
+    }
+
+    async getOrCreateStream(
+        schema: Schema,
+        connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration,
+        configuration: DPMConfiguration,
+        jobContext: JobContext
+    ): Promise<void> {
+        const timeplusStreamName = (configuration as Record<string, string>)[("stream-name-" + schema.title) as string];
+
+        const task = await jobContext.startTask("Finding existing Timeplus Stream for " + timeplusStreamName);
+
+        let stream: TimeplusStream | undefined;
+
+        const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
+        // jobContext.print("INFO", "Sending GET to " + url);
+
+        const response = await fetch(url, {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: `Bearer ${getAuthToken(credentialsConfiguration)}`
+            }
+        });
+        // jobContext.print("INFO", "Got response with HTTP code " + response.status);
+
+        if (response.status !== 200) {
+            throw new Error(`Failed to list Timeplus streams. HTTP code: ${response.status} ${response.statusText}`);
+        }
+        const rv = await response.json();
+        const listStreamsResponse = rv as ListStreamsResponse;
+
+        stream = listStreamsResponse.find((s) => s.name === timeplusStreamName);
+
+        if (!stream) {
+            task.setMessage("Timeplus Stream " + timeplusStreamName + " does not exist, creating");
+
+            const timeplusColumns = this.getTimeplusColumns(schema);
+
+            const requestBody = JSON.stringify({
+                name: timeplusStreamName,
+                // description: "Created by DataPM",
+                columns: timeplusColumns
+            });
+
+            const response = await fetch(`https://${connectionConfiguration.host}/api/v1beta1/streams`, {
+                method: "POST",
+                headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${getAuthToken(credentialsConfiguration)}`
+                },
+                body: requestBody
+            });
+
+            if (response.status !== 201) {
+                // jobContext.print("INFO", "Timeplus Request Body Below");
+                // jobContext.print("INFO", requestBody);
+                throw new Error(
+                    "Unable to create Timeplus stream. Response code: " + response.status + " body: " + response.text()
+                );
+            }
+
+            stream = (await response.json()) as TimeplusStream;
+
+            task.end("SUCCESS", "Created Timeplus Stream " + timeplusStreamName);
+        } else {
+            task.end("SUCCESS", "Found Timeplus Stream " + timeplusStreamName);
+        }
+    }
+
+    getTimeplusColumns(schema: Schema): TimeplusColumns {
+        if (schema.properties == null) {
+            throw new Error("Schema must have properties");
+        }
+
+        return Object.keys(schema.properties).map((propertyName) => {
+            const property = schema.properties?.[propertyName];
+            // console.log("[debug] propertyName:" + propertyName + " property:" + JSON.stringify(property));
+
+            if (property == null) {
+                throw new Error("Schema property " + propertyName + " is not found");
+            }
+
+            if (property.title == null) {
+                throw new Error("Schema property " + propertyName + " must have a title");
+            }
+
+            return {
+                // column definition
+                name: property.title,
+                type: this.getTimeplusType(property.type as JSONSchema7TypeName[], property.format)
+            };
+        });
+    }
+
+    getTimeplusType(types: string[], format?: string): string {
+        // console.log("[debug] type:" + types + " format:" + format);
+        const removedNull = types.filter((t) => t !== "null");
+
+        if (removedNull.length > 1) {
+            throw new Error("Timeplus Sink does not support schemas with more than one type");
+        }
+
+        if (removedNull.length === 0) {
+            throw new Error("column has no value types");
+        }
+
+        switch (removedNull[0]) {
+            case "string":
+                return "string";
+            case "integer":
+                return "int";
+            case "number":
+                switch (format) {
+                    case "float":
+                        return "float";
+                    case "integer":
+                        return "int";
+                    default:
+                        return "double";
+                }
+            case "boolean":
+                return "bool";
+            default:
+                throw new Error("Unsupported Timeplus type: " + removedNull[0]);
+        }
+    }
+}

--- a/client-lib/src/connector/timeplus/TimeplusSinkDescription.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSinkDescription.ts
@@ -1,0 +1,17 @@
+import { Sink, SinkDescription } from "../Sink";
+import { DISPLAY_NAME, TYPE } from "./TimeplusConnectorDescription";
+
+export class TimeplusSinkDescription implements SinkDescription {
+    getType(): string {
+        return TYPE;
+    }
+
+    getDisplayName(): string {
+        return DISPLAY_NAME;
+    }
+
+    async loadSinkFromModule(): Promise<Sink> {
+        const source = await import("./TimeplusSink");
+        return new source.TimeplusSink();
+    }
+}


### PR DESCRIPTION
Hi @traviscollins ,

Here is the PR to add a new sink connector in datapm to send data to Timeplus, a fast, powerful, intuitive real-time analytics platform.

There are 4 new files in client-lib/src/connector/timeplus/ folder and also register this connector in client-lib/src/connector/ConnectorUtil.ts

To test this connector, please join the Timeplus beta and get a tenant, such as `datapm.beta.timeplus.com` and acquire the API token in the Help page. If you type a stream name and the stream doesn't exist in your Timeplus tenant, the connector will call API to create the stream with the inferred data schema. During the data ingestion, you can view the live data via Timeplus query page
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/5076438/166158960-45694c4f-cf74-42e6-bc68-438c7cb380c3.png">

The host name and token are saved in the similar way as the Kafka sink.

End to end test:

> Inspecting binance
> ℹ Connecting to wss://stream.binance.com:9443/stream
> 
> Sink Connector
> ✔ Sink Connector? › Timeplus
> ✔ Found the connector named Timeplus
> 
> Timeplus Connection
> ✔ Repository? › datapm.beta.timeplus.com
> ✔ Connection successful
> 
> Timeplus Credentials
> ✔ Credentials? › eyJ..fdw
> ✔ Authentication succeeded
> 
> Timeplus Configuration
> ✔ Stream for bookTicker records? … jove1
> ✔ Created Timeplus Stream jove1
> 
> Checking State of binance-websocket
> ✔ New records may be available
> 
> Reading binance-websocket
> ✔ Success
> ✔ Finished writing 155 records