### PR TITLE
Timeplus sink: use empty string for null or {}, stringify json, ignore failed ingestion

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -167,9 +167,11 @@ export class TimeplusSink implements Sink {
                             if (i === 0) {
                                 columns.push(columnName);
                             }
-                            // if (that.columnTypeCache.get(columnName) === "json")
-                            if (columnValue == null) {
-                                row.push(""); // set an empty string
+                            if (columnValue == null || Object.keys(columnValue).length === 0) {
+                                row.push(" "); // set an empty string if the value is null or an empty json object
+                            } else if (typeof columnValue === "object") {
+                                // if (that.columnTypeCache.get(columnName) === "json")
+                                row.push(JSON.stringify(columnValue));
                             } else {
                                 row.push(columnValue);
                             }
@@ -197,11 +199,11 @@ export class TimeplusSink implements Sink {
                     // shall we use 202?
                     if (response.status !== 200) {
                         const msg = `Unexpected response status ${response.status} body ${await response.text()}`;
+                        jobContext.print("WARN", `Fail to ingest data in batch, with error message: ${msg}`);
                         // console.log(bodyStr);
-                        callback(new Error(msg));
-                        return;
+                        // callback(new Error(msg));
+                        // return;
                     }
-
                     callback(null, records[records.length - 1]);
                 }
             })


### PR DESCRIPTION
I found the Timeplus server will report error if one field is {} or null, in this fix, use " " (a whitespace) as the value
for complex value("object" type), directly sending the raw object can be risky too, so in this fix, change it to a string via `JSON.stringify(columnValue)`

Another important enhancement to skip the ingestion if the REST API returns error. Use `jobContext.print("WARN"` to show the warning and carry on