### PR TITLE
Timeplus sink: switched from api token to api key

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -33,11 +33,10 @@ export class TimeplusConnector implements Connector {
         _connectionConfiguration: DPMConfiguration,
         credentialsConfiguration: DPMConfiguration
     ): Promise<string | undefined> {
-        if (credentialsConfiguration.token != null) {
-            const token = credentialsConfiguration.token as string;
-            return token;
-            // only show the first 4 chars and the last 4 chars
-            // return token.substring(0, 4) + "**" + token.substring(token.length - 3);
+        if (credentialsConfiguration.apiKey != null) {
+            const apiKey = credentialsConfiguration.apiKey as string;
+            // only show the first 20 chars(key id)
+            return apiKey.substring(0, 20);
         }
 
         return undefined;
@@ -60,18 +59,20 @@ export class TimeplusConnector implements Connector {
     }
 
     getCredentialsParameters(
-        _connectionConfiguration: DPMConfiguration,
-        authenticationConfiguration: DPMConfiguration,
+        connectionConfiguration: DPMConfiguration,
+        credentialsConfiguration: DPMConfiguration,
         jobContext: JobContext
     ): Parameter[] | Promise<Parameter[]> {
         const parameters: Parameter[] = [];
 
-        if (authenticationConfiguration.token == null) {
+        if (credentialsConfiguration.apiKey == null) {
             parameters.push({
-                configuration: authenticationConfiguration,
+                configuration: credentialsConfiguration,
                 type: ParameterType.Password,
-                name: "token",
-                message: "API Token?"
+                name: "apiKey",
+                message: "API Key?",
+                stringMinimumLength: 60,
+                stringMaximumLength: 60
             });
         }
 
@@ -87,12 +88,12 @@ export class TimeplusConnector implements Connector {
         connectionConfiguration: DPMConfiguration,
         credentialsConfiguration: DPMConfiguration
     ): Promise<string | true> {
-        const authToken = getAuthToken(credentialsConfiguration);
+        const apiKey = getApiKey(credentialsConfiguration);
         const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
 
         const resp = await fetch(url, {
             headers: {
-                Authorization: `Bearer ${authToken}`,
+                "X-Api-Key": apiKey,
                 Accept: "application/json"
             }
         });
@@ -104,12 +105,12 @@ export class TimeplusConnector implements Connector {
         return true;
     }
 }
-export function getAuthToken(credentialsConfiguration: DPMConfiguration): string {
-    const accessToken = credentialsConfiguration.token as string;
+export function getApiKey(credentialsConfiguration: DPMConfiguration): string {
+    const apiKey = credentialsConfiguration.apiKey as string;
 
-    if (accessToken == null) {
-        throw new Error("Timeplus token is not set.");
+    if (apiKey == null) {
+        throw new Error("Timeplus API key is not set.");
     }
 
-    return accessToken;
+    return apiKey;
 }

--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -19,7 +19,7 @@ import { JobContext } from "../../task/JobContext";
 import { Maybe } from "../../util/Maybe";
 import { StreamSetProcessingMethod } from "../../util/StreamToSinkUtil";
 import { CommitKey, Sink, SinkSupportedStreamOptions, WritableWithContext } from "../Sink";
-import { getAuthToken } from "./TimeplusConnector";
+import { getApiKey } from "./TimeplusConnector";
 import { DISPLAY_NAME, TYPE } from "./TimeplusConnectorDescription";
 import { fetch } from "cross-fetch";
 import { SemVer } from "semver";
@@ -134,7 +134,7 @@ export class TimeplusSink implements Sink {
         if (schema.properties == null) throw new Error("Schema properties not definied, and are required");
         const keys = Object.keys(schema.properties);
 
-        const authToken = getAuthToken(credentialsConfiguration);
+        const apiKey = getApiKey(credentialsConfiguration);
 
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const that = this;
@@ -194,7 +194,7 @@ export class TimeplusSink implements Sink {
                     const response = await fetch(ingestURL, {
                         method: "POST",
                         headers: {
-                            Authorization: `Bearer ${authToken}`,
+                            "X-Api-Key": apiKey,
                             "Content-Type": "application/json",
                             Accept: "application/json"
                         },
@@ -256,11 +256,13 @@ export class TimeplusSink implements Sink {
 
         const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
 
+        const apiKey = getApiKey(credentialsConfiguration);
+
         const response = await fetch(url, {
             method: "GET",
             headers: {
                 Accept: "application/json",
-                Authorization: `Bearer ${getAuthToken(credentialsConfiguration)}`
+                "X-Api-Key": apiKey
             }
         });
 
@@ -288,7 +290,7 @@ export class TimeplusSink implements Sink {
                 headers: {
                     Accept: "application/json",
                     "Content-Type": "application/json",
-                    Authorization: `Bearer ${getAuthToken(credentialsConfiguration)}`
+                    "X-Api-Key": apiKey
                 },
                 body: requestBody
             });


### PR DESCRIPTION
At Timeplus, we are now switching from tenant level access token to per user API key.
There will be a new web UI to create API key, with a name (required) and expiration date (optional)
The previous access token is not bounded to a user and the max age is 30 days, which is not suitable for long-running job.

The API key is fixed size, the first 20 chars is the key id and the next 40 chars are the key secret. The user will get the entire string (60 chars) when they create the apikey on UI.