### PR TITLE
Support Timeplus Private Beta 2 multitenant API

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -26,7 +26,10 @@ export class TimeplusConnector implements Connector {
         if (typeof connectionConfiguration.host !== "string") {
             throw new Error("Timeplus host not set");
         }
-        return connectionConfiguration.host;
+        if (typeof connectionConfiguration.tenant !== "string") {
+            throw new Error("Timeplus tenant not set");
+        }
+        return connectionConfiguration.host + "#" + connectionConfiguration.tenant;
     }
 
     async getCredentialsIdentifierFromConfiguration(
@@ -51,7 +54,16 @@ export class TimeplusConnector implements Connector {
                 type: ParameterType.Text,
                 stringMinimumLength: 1,
                 configuration: connectionConfiguration,
-                message: "Host Name(e.g. a.beta.timeplus.com)?"
+                message: "Host Name(e.g. beta.timeplus.cloud)?"
+            });
+        }
+        if (connectionConfiguration.tenant == null) {
+            parameters.push({
+                name: "tenant",
+                type: ParameterType.Text,
+                stringMinimumLength: 1,
+                configuration: connectionConfiguration,
+                message: "Tenant ID(e.g. datapm)?"
             });
         }
 
@@ -89,7 +101,7 @@ export class TimeplusConnector implements Connector {
         credentialsConfiguration: DPMConfiguration
     ): Promise<string | true> {
         const apiKey = getApiKey(credentialsConfiguration);
-        const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
+        const url = `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`;
 
         const resp = await fetch(url, {
             headers: {

--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -54,7 +54,8 @@ export class TimeplusConnector implements Connector {
                 type: ParameterType.Text,
                 stringMinimumLength: 1,
                 configuration: connectionConfiguration,
-                message: "Host Name(e.g. beta.timeplus.cloud)?"
+                defaultValue: "beta.timeplus.cloud",
+                message: "Host Name?"
             });
         }
         if (connectionConfiguration.tenant == null) {

--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -143,7 +143,7 @@ export class TimeplusSink implements Sink {
             getCommitKeys: () => {
                 return [] as CommitKey[];
             },
-            outputLocation: `https://${connectionConfiguration.host}/api/v1beta1/streams`,
+            outputLocation: `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`,
             lastOffset: undefined,
             transforms: [new BatchingTransform(100, 100)],
             writable: new Transform({
@@ -188,9 +188,9 @@ export class TimeplusSink implements Sink {
                         data: rows
                     };
                     const bodyStr = JSON.stringify(data);
-                    const ingestURL = `https://${connectionConfiguration.host}/api/v1beta1/streams/${
-                        configuration["stream-name-" + schema.title]
-                    }/ingest`;
+                    const ingestURL = `https://${connectionConfiguration.host}/${
+                        connectionConfiguration.tenant
+                    }/api/v1beta1/streams/${configuration["stream-name-" + schema.title]}/ingest`;
                     const response = await fetch(ingestURL, {
                         method: "POST",
                         headers: {
@@ -254,7 +254,7 @@ export class TimeplusSink implements Sink {
 
         let stream: TimeplusStream | undefined;
 
-        const url = `https://${connectionConfiguration.host}/api/v1beta1/streams`;
+        const url = `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`;
 
         const apiKey = getApiKey(credentialsConfiguration);
 
@@ -285,15 +285,18 @@ export class TimeplusSink implements Sink {
                 columns: timeplusColumns
             });
 
-            const response = await fetch(`https://${connectionConfiguration.host}/api/v1beta1/streams`, {
-                method: "POST",
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                    "X-Api-Key": apiKey
-                },
-                body: requestBody
-            });
+            const response = await fetch(
+                `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`,
+                {
+                    method: "POST",
+                    headers: {
+                        Accept: "application/json",
+                        "Content-Type": "application/json",
+                        "X-Api-Key": apiKey
+                    },
+                    body: requestBody
+                }
+            );
 
             if (response.status !== 201) {
                 // jobContext.print("INFO", "Timeplus Request Body Below");


### PR DESCRIPTION
the API endpoint became https://beta.timeplus.cloud/TENANT_ID/api/.. for the beta2
add tenant parameter in the CLI promo, set beta.timeplus.cloud as the default host. Tested locally with API key for https://beta.timeplus.cloud/datapm/