### PR TITLE
fix: Correctly format decodable timestamps

### DIFF
--- a/client-lib/src/connector/decodable/DecodableSink.spec.ts
+++ b/client-lib/src/connector/decodable/DecodableSink.spec.ts
@@ -62,7 +62,7 @@ describe("Decodable Sink Unit Tests", () => {
             }
         };
         const timestampArray = getDecodableType(properties.timestampArray.types);
-        expect(timestampArray).equal("ARRAY<TIMESTAMP(3)>");
+        expect(timestampArray).equal("ARRAY<TIMESTAMP_LTZ(3)>");
 
         const stringArray = getDecodableType(properties.stringArray.types);
         expect(stringArray).equal("ARRAY<STRING>");


### PR DESCRIPTION
Worked with Decodable team to align DataPM generated schemas and values with their expected formats.