### PR TITLE
Enhance timeplus sink to support baseURL

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -23,13 +23,10 @@ export class TimeplusConnector implements Connector {
     }
 
     async getRepositoryIdentifierFromConfiguration(connectionConfiguration: DPMConfiguration): Promise<string> {
-        if (typeof connectionConfiguration.host !== "string") {
-            throw new Error("Timeplus host not set");
+        if (typeof connectionConfiguration.base !== "string") {
+            throw new Error("Timeplus base URL not set");
         }
-        if (typeof connectionConfiguration.tenant !== "string") {
-            throw new Error("Timeplus tenant not set");
-        }
-        return connectionConfiguration.host + "#" + connectionConfiguration.tenant;
+        return connectionConfiguration.base;
     }
 
     async getCredentialsIdentifierFromConfiguration(
@@ -48,23 +45,14 @@ export class TimeplusConnector implements Connector {
     getConnectionParameters(connectionConfiguration: DPMConfiguration): Parameter[] | Promise<Parameter[]> {
         const parameters: Parameter[] = [];
 
-        if (connectionConfiguration.host == null) {
+        if (connectionConfiguration.base == null) {
             parameters.push({
-                name: "host",
+                name: "base",
                 type: ParameterType.Text,
                 stringMinimumLength: 1,
                 configuration: connectionConfiguration,
-                defaultValue: "beta.timeplus.cloud",
-                message: "Host Name?"
-            });
-        }
-        if (connectionConfiguration.tenant == null) {
-            parameters.push({
-                name: "tenant",
-                type: ParameterType.Text,
-                stringMinimumLength: 1,
-                configuration: connectionConfiguration,
-                message: "Tenant ID(e.g. datapm)?"
+                defaultValue: "https://beta.timeplus.cloud/workspace-id",
+                message: "Base URL?"
             });
         }
 
@@ -102,7 +90,7 @@ export class TimeplusConnector implements Connector {
         credentialsConfiguration: DPMConfiguration
     ): Promise<string | true> {
         const apiKey = getApiKey(credentialsConfiguration);
-        const url = `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`;
+        const url = `${connectionConfiguration.base}/api/v1beta1/streams`;
 
         const resp = await fetch(url, {
             headers: {

--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -143,7 +143,7 @@ export class TimeplusSink implements Sink {
             getCommitKeys: () => {
                 return [] as CommitKey[];
             },
-            outputLocation: `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`,
+            outputLocation: `${connectionConfiguration.base}/api/v1beta1/streams`,
             lastOffset: undefined,
             transforms: [new BatchingTransform(100, 100)],
             writable: new Transform({
@@ -188,15 +188,15 @@ export class TimeplusSink implements Sink {
                         data: rows
                     };
                     const bodyStr = JSON.stringify(data);
-                    const ingestURL = `https://${connectionConfiguration.host}/${
-                        connectionConfiguration.tenant
-                    }/api/v1beta1/streams/${configuration["stream-name-" + schema.title]}/ingest`;
+                    const ingestURL = `${connectionConfiguration.base}/api/v1beta1/streams/${
+                        configuration["stream-name-" + schema.title]
+                    }/ingest`;
                     const response = await fetch(ingestURL, {
                         method: "POST",
                         headers: {
                             "X-Api-Key": apiKey,
                             "Content-Type": "application/json",
-                            Accept: "application/json"
+                            Accept: "application/json" // don't use application/x-ndjson, because the batch mode is more performant
                         },
                         body: bodyStr
                     });
@@ -254,7 +254,7 @@ export class TimeplusSink implements Sink {
 
         let stream: TimeplusStream | undefined;
 
-        const url = `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`;
+        const url = `${connectionConfiguration.base}/api/v1beta1/streams`;
 
         const apiKey = getApiKey(credentialsConfiguration);
 
@@ -285,18 +285,15 @@ export class TimeplusSink implements Sink {
                 columns: timeplusColumns
             });
 
-            const response = await fetch(
-                `https://${connectionConfiguration.host}/${connectionConfiguration.tenant}/api/v1beta1/streams`,
-                {
-                    method: "POST",
-                    headers: {
-                        Accept: "application/json",
-                        "Content-Type": "application/json",
-                        "X-Api-Key": apiKey
-                    },
-                    body: requestBody
-                }
-            );
+            const response = await fetch(`${connectionConfiguration.base}/api/v1beta1/streams`, {
+                method: "POST",
+                headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                    "X-Api-Key": apiKey
+                },
+                body: requestBody
+            });
 
             if (response.status !== 201) {
                 // jobContext.print("INFO", "Timeplus Request Body Below");


### PR DESCRIPTION
Previously the user need to set the timeplus host and tenant ID.
In this PR, only the baseURL need to be set, such as `https://beta.timeplus.cloud/datapm`
This makes it possible to support other Timeplus deployments (in other regions or even onprem), even plain HTTP could be supported

API Key is still required