### PR TITLE
change beta.timeplus.cloud to us.timeplus.cloud

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -51,7 +51,7 @@ export class TimeplusConnector implements Connector {
                 type: ParameterType.Text,
                 stringMinimumLength: 1,
                 configuration: connectionConfiguration,
-                defaultValue: "https://beta.timeplus.cloud/workspace-id",
+                defaultValue: "https://us.timeplus.cloud/workspace-id",
                 message: "Base URL?"
             });
         }


### PR DESCRIPTION
A very straightforward change: we are deprecating beta.timeplus.cloud and started using us.timeplus.cloud