### PR TITLE
replace api/v1beta1 to api/v1beta2

### DIFF
--- a/client-lib/src/connector/timeplus/TimeplusConnector.ts
+++ b/client-lib/src/connector/timeplus/TimeplusConnector.ts
@@ -90,7 +90,7 @@ export class TimeplusConnector implements Connector {
         credentialsConfiguration: DPMConfiguration
     ): Promise<string | true> {
         const apiKey = getApiKey(credentialsConfiguration);
-        const url = `${connectionConfiguration.base}/api/v1beta1/streams`;
+        const url = `${connectionConfiguration.base}/api/v1beta2/streams`;
 
         const resp = await fetch(url, {
             headers: {

--- a/client-lib/src/connector/timeplus/TimeplusSink.ts
+++ b/client-lib/src/connector/timeplus/TimeplusSink.ts
@@ -143,7 +143,7 @@ export class TimeplusSink implements Sink {
             getCommitKeys: () => {
                 return [] as CommitKey[];
             },
-            outputLocation: `${connectionConfiguration.base}/api/v1beta1/streams`,
+            outputLocation: `${connectionConfiguration.base}/api/v1beta2/streams`,
             lastOffset: undefined,
             transforms: [new BatchingTransform(100, 100)],
             writable: new Transform({
@@ -188,7 +188,7 @@ export class TimeplusSink implements Sink {
                         data: rows
                     };
                     const bodyStr = JSON.stringify(data);
-                    const ingestURL = `${connectionConfiguration.base}/api/v1beta1/streams/${
+                    const ingestURL = `${connectionConfiguration.base}/api/v1beta2/streams/${
                         configuration["stream-name-" + schema.title]
                     }/ingest`;
                     const response = await fetch(ingestURL, {
@@ -254,7 +254,7 @@ export class TimeplusSink implements Sink {
 
         let stream: TimeplusStream | undefined;
 
-        const url = `${connectionConfiguration.base}/api/v1beta1/streams`;
+        const url = `${connectionConfiguration.base}/api/v1beta2/streams`;
 
         const apiKey = getApiKey(credentialsConfiguration);
 
@@ -285,7 +285,7 @@ export class TimeplusSink implements Sink {
                 columns: timeplusColumns
             });
 
-            const response = await fetch(`${connectionConfiguration.base}/api/v1beta1/streams`, {
+            const response = await fetch(`${connectionConfiguration.base}/api/v1beta2/streams`, {
                 method: "POST",
                 headers: {
                     Accept: "application/json",


### PR DESCRIPTION
We have depreciated api/v1beta1 and going to remove it

This PR simply replaced v1beta1 call to v1beta2.